### PR TITLE
Introduce offline state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 #Plight
+[![Build Status](https://travis-ci.org/rackerlabs/plight.svg?branch=master)](https://travis-ci.org/rackerlabs/plight)
 
 ## Description
 An Application and Load Balancer agnostic tool to control node availability in load balancer pools.

--- a/plight.conf
+++ b/plight.conf
@@ -14,5 +14,19 @@ loglevel = INFO
 filesize = 1024000
 rotationcount = 10
 
-[permanents]
-statefile = /var/lib/plight/node_disabled
+[priorities]
+states=enabled,disabled,offline
+
+[disabled]
+file = /var/lib/plight/node_disabled
+code = 404
+message = node is unavailable
+
+[enabled]
+code = 200
+message = node is available
+
+[offline]
+file = /var/lib/plight/node_offline
+code = 503
+message = node is offline

--- a/plight.spec
+++ b/plight.spec
@@ -4,8 +4,8 @@
 %{!?_unitdir: %define _unitdir /usr/lib/systemd/system}
 
 Name:           plight
-Version:        0.0.4
-Release:        4%{?dist}
+Version:        0.1.0
+Release:        1%{?dist}
 Group:          Applications/Systems
 Summary:        Load balancer agnostic node state control service
 
@@ -115,6 +115,9 @@ fi
 %endif
 
 %changelog
+* Mon Apr 06 2015 Greg Swift <greg.swift@rackspace.com> - 0.1.0-1
+- Introduce offline mode
+
 * Fri Jan 09 2015 Chad Wilson <chad.wilson@rackspace.com> - 0.0.4-4
 - leave service restart on update to postuninstall scriptlet
 
@@ -145,7 +148,7 @@ fi
 * Tue Mar 25 2014 Greg Swift <greg.swift@rackspace.com> - 0.0.2-3
 - bump of release for copr build system for el5
 
-* Tue Feb 05 2014 Alex Schultz <alex.schultz@rackspace.com> - 0.0.2-2
+* Wed Feb 05 2014 Alex Schultz <alex.schultz@rackspace.com> - 0.0.2-2
 - python-setuptools is required to run the plight command
 
 * Wed Jan 29 2014 Alex Schultz <alex.schultz@rackspace.com> - 0.0.2-1

--- a/plight/__init__.py
+++ b/plight/__init__.py
@@ -21,7 +21,6 @@ except ImportError:
     from http.server import test as http_server_test
     from http.server import SimpleHTTPRequestHandler
 
-
 STATE_FILE = '/var/tmp/node_disabled'
 CONFIG_FILE = '/etc/plight.conf'
 

--- a/plight/util.py
+++ b/plight/util.py
@@ -126,6 +126,7 @@ def cli_fail():
     exit(1)
 
 
+
 def run():
     try:
         mode = sys.argv[1].lower()

--- a/plight/util.py
+++ b/plight/util.py
@@ -29,28 +29,95 @@ PID_FILE = '/var/run/plight/plight.pid'
 
 
 def get_config(config_file=plight.CONFIG_FILE):
-    config = ConfigParser.ConfigParser()
-    config.read(config_file)
-    return {
-        'host': config.get('webserver', 'host'),
-        'port': config.getint('webserver', 'port'),
-        'user': config.get('webserver', 'user'),
-        'group': config.get('webserver', 'group'),
-        'web_log_file': config.get('webserver', 'logfile'),
+    parser = ConfigParser.ConfigParser()
+    parser.read(config_file)
+    config = {
+        'host': parser.get('webserver', 'host'),
+        'port': parser.getint('webserver', 'port'),
+        'user': parser.get('webserver', 'user'),
+        'group': parser.get('webserver', 'group'),
+        'web_log_file': parser.get('webserver', 'logfile'),
         'web_log_level': getattr(logging,
-                                 config.get('webserver', 'loglevel')),
-        'web_log_filesize': config.getint('webserver', 'filesize'),
-        'web_log_rotation_count': config.getint('webserver', 'rotationcount'),
-        'state_file': config.get('permanents', 'statefile'),
-        'log_file': config.get('logging', 'logfile'),
+                                 parser.get('webserver', 'loglevel')),
+        'web_log_filesize': parser.getint('webserver', 'filesize'),
+        'web_log_rotation_count': parser.getint('webserver', 'rotationcount'),
+        'log_file': parser.get('logging', 'logfile'),
         'log_level': getattr(logging,
-                             config.get('logging', 'loglevel')),
-        'log_filesize': config.getint('logging', 'filesize'),
-        'log_rotation_count': config.getint('logging', 'rotationcount')
+                             parser.get('logging', 'loglevel')),
+        'log_filesize': parser.getint('logging', 'filesize'),
+        'log_rotation_count': parser.getint('logging', 'rotationcount')
     }
+    logger = logging.getLogger('plight')
+    logger.setLevel(config['log_level'])
+    config['states'] = process_states_from_config(parser, logger)
+    return config
 
 
-def start_server(config):
+def process_states_from_config(parser, logger):
+    # The old state_file setup was the true/false existance
+    # of state_file. If the old configuration setup is being used,
+    # we want to reproduce that behavior. The definition of
+    # state_file will act as old vs new configuration key.
+    state_file = None
+    # Load in the default states
+    states = plight.STATES
+    try:
+        state_file = parser.get('permanents', 'statefile')
+    except ConfigParser.NoSectionError:
+        pass
+    if state_file is not None:
+        logger.warn('Permanents section is deprecated, see release notes')
+        states['disabled']['file'] = state_file
+        states['disabled']['old_config'] = True
+        del states['offline']
+    if 'old_config' not in states['disabled']:
+        # We are on the new config.  Valid states are pulled
+        # from the defined priorities.states, which should be ordered
+        # from lowest to highest priority.
+        err = None
+        try:
+            priorities = parser.get('priorities', 'states').split(',')
+        except ConfigParser.NoSectionError:
+            err = 'No priorities section defined in config file'
+        except ConfigParser.NoOptionError:
+            err = 'Missing states option in priorities section of config file'
+        finally:
+            if err:
+                logger.error(err)
+                raise Exception(err)
+        # Based on the defined priorties we want to remove unused states
+        keep_states = {}
+        for state in states:
+            if state in priorities:
+                keep_states[state] = states[state]
+        states = keep_states
+        # Now we want to loop through the requested states
+        for state in priorities:
+            # Error if values aren't provided
+            if not parser.has_section(state) and state not in states:
+                err = 'Priorities contains undefined state {0}'.format(state)
+                logger.error(err)
+                raise Exception(err)
+            if state not in states:
+                states[state] = {'priority': priorities.index(state)}
+            for option in plight.STATES['enabled']:
+                try:
+                    states[state][option] = parser.get(state, option)
+                except ConfigParser.NoOptionError:
+                    if option in ['command', 'priority']:
+                        continue
+                    if option == 'file':
+                        states[state][option] = None
+                        continue
+                    raise
+                try:
+                    states[state][option] = int(states[state][option])
+                except ValueError:
+                    pass
+    return states
+
+
+def start_server(config, node):
     weblogger = logging.getLogger('plight_httpd')
     weblogger.setLevel(config['web_log_level'])
     if weblogger.handlers == []:
@@ -65,12 +132,11 @@ def start_server(config):
     applogger = logging.getLogger('plight')
     applogger.setLevel(config['log_level'])
     if applogger.handlers == []:
-        applogging_handler = RotatingFileHandler(config['log_file'],
-                                                 mode='a',
-                                                 maxBytes=config[
-                                                      'log_filesize'],
-                                                 backupCount=config[
-                                                      'log_rotation_count'])
+        applogging_handler = RotatingFileHandler(
+            config['log_file'],
+            mode='a',
+            maxBytes=config['log_filesize'],
+            backupCount=config['log_rotation_count'])
         applogger.addHandler(applogging_handler)
 
     pidfile = PIDLockFile(PID_FILE)
@@ -89,7 +155,6 @@ def start_server(config):
     try:
         try:
             log_message('Plight is starting...')
-            node_status = plight.NodeStatus(config['state_file'])
             server_class = BaseHTTPServer.HTTPServer
             http = server_class((config['host'],
                                  config['port']),
@@ -121,28 +186,29 @@ def stop_server():
         print('no pid file available')
 
 
-def cli_fail():
-    sys.stderr.write('{0} [start|enable|disable|stop]\n'.format(sys.argv[0]))
+def cli_fail(commands):
+    fail_msg = '{0} [start|{1}|stop]\n'
+    commands = "|".join(commands)
+    sys.stderr.write(fail_msg.format(sys.argv[0], commands))
     exit(1)
 
 
-
 def run():
+    config = get_config()
+    node = plight.NodeStatus(states=config['states'])
+
     try:
         mode = sys.argv[1].lower()
     except IndexError:
-        cli_fail()
+        cli_fail(node._commands)
     except AttributeError:
-        cli_fail()
+        cli_fail(node._commands)
 
-    config = get_config()
-
-    if mode.lower() in ['enable', 'disable']:
-        node = plight.NodeStatus(state_file=config['state_file'])
+    if mode in node._commands:
         node.set_node_state(mode)
-    elif mode.lower() == 'start':
-        start_server(config)
-    elif mode.lower() == 'stop':
+    elif mode == 'start':
+        start_server(config, node)
+    elif mode == 'stop':
         stop_server()
     else:
-        cli_fail()
+        cli_fail(node._commands)

--- a/tests/test_plight.py
+++ b/tests/test_plight.py
@@ -5,13 +5,25 @@ import plight
 def status(request):
     status = plight.NodeStatus()
     def reset():
-         status.set_node_enabled()
+        status.set_node_enabled()
     request.addfinalizer(reset)
     return status
 
+# Test enabling
 def test_default_nodestatus(status):
     assert status.get_node_state() == 'ENABLED'
 
+def test_reset_state_enabled_from_disabled_nodestatus(status):
+    status.set_node_state('disable')
+    status.set_node_state('enable')
+    assert status.get_node_state() == 'ENABLED'
+
+def test_reset_state_enabled_from_offline_nodestatus(status):
+    status.set_node_state('offline')
+    status.set_node_state('enable')
+    assert status.get_node_state() == 'ENABLED'
+
+# Test disabling
 def test_set_disabled_nodestatus(status):
     status.set_node_disabled()
     assert status.get_node_state() == 'DISABLED'
@@ -20,7 +32,22 @@ def test_set_state_disabled_nodestatus(status):
     status.set_node_state('disable')
     assert status.get_node_state() == 'DISABLED'
 
-def test_reset_state_enabled_nodestatus(status):
+def test_reset_state_disabled_from_offline_nodestatus(status):
+    status.set_node_state('offline')
     status.set_node_state('disable')
-    status.set_node_state('enable')
-    assert status.get_node_state() == 'ENABLED'
+    assert status.get_node_state() == 'DISABLED'
+
+# Test offline
+def test_set_offline_nodestatus(status):
+    status.set_node_offline()
+    assert status.get_node_state() == 'OFFLINE'
+
+def test_set_state_offline_nodestatus(status):
+    status.set_node_state('offline')
+    assert status.get_node_state() == 'OFFLINE'
+
+def test_reset_state_offline_from_disabled_nodestatus(status):
+    status.set_node_state('disable')
+    status.set_node_state('offline')
+    assert status.get_node_state() == 'OFFLINE'
+

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,7 +3,7 @@ import os
 import plight.util as util
 
 
-GENERIC_CONFIG="""
+GENERIC_OLD_CONFIG="""
 [webserver]
 port = 10101
 host = 0.0.0.0
@@ -24,8 +24,83 @@ rotationcount = 10
 statefile = /var/lib/plight/node_disabled
 """
 
+GENERIC_CONFIG="""
+[webserver]
+port = 10101
+host = 0.0.0.0
+user = plight
+group = plight
+logfile = /var/log/plight/access.log
+loglevel = INFO
+filesize = 1024000
+rotationcount = 10
+
+[logging]
+logfile = /var/log/plight/plight.log
+loglevel = INFO
+filesize = 1024000
+rotationcount = 10
+
+[priorities]
+states=enabled,disabled,offline
+
+[disabled]
+file = /var/lib/plight/node_disabled
+command = disable
+code = 200
+message = node is unavailable
+
+[enabled]
+command = enable
+code = 200
+message = node is available
+
+[offline]
+file = /var/lib/plight/node_offline
+code = 200
+message = node is offline
+"""
+
+ALTERNATE_CONFIG="""
+[webserver]
+port = 10101
+host = 0.0.0.0
+user = plight
+group = plight
+logfile = /var/log/plight/access.log
+loglevel = INFO
+filesize = 1024000
+rotationcount = 10
+
+[logging]
+logfile = /var/log/plight/plight.log
+loglevel = INFO
+filesize = 1024000
+rotationcount = 10
+
+[priorities]
+states=master,slave,offline
+
+[master]
+code = 200
+message = master node
+
+[slave]
+file = /var/lib/plight/node_slave
+code = 200
+message = slave node
+
+[offline]
+file = /var/lib/plight/node_offline
+code = 200
+message = node is offline
+"""
+
+
 @pytest.fixture(scope='function',
-                params=[GENERIC_CONFIG])
+                params=[GENERIC_OLD_CONFIG,
+                        GENERIC_CONFIG,
+                        ALTERNATE_CONFIG])
 def config_file(request, tmpdir):
     file = tmpdir.join('config')
     open(file.strpath, 'w').write(request.param)
@@ -39,4 +114,36 @@ def test_get_config(config_file):
     assert config['port'] == 10101
     assert config['web_log_file'] == '/var/log/plight/access.log'
     assert config['log_file'] == '/var/log/plight/plight.log'
-    assert config['state_file'] == '/var/lib/plight/node_disabled'
+    if 'enabled' in config['states']:
+        state = config['states']['enabled']
+        assert state['file'] == None
+        assert state['code'] == 200
+        assert state['priority'] == 0
+
+    if 'disabled' in config['states']:
+        state = config['states']['disabled']
+        assert state['file'] == '/var/lib/plight/node_disabled'
+        if 'old_config' in state and state['old_config']:
+            assert state['code'] == 404
+        else:
+            assert state['code'] == 200
+        assert state['command'] == 'disable'
+        assert state['priority'] == 1
+
+    if 'offline' in config['states']:
+        state = config['states']['offline']
+        assert state['file'] == '/var/lib/plight/node_offline'
+        assert state['code'] == 200
+        assert state['priority'] == 2
+
+    if 'master' in config['states']:
+        state = config['states']['master']
+        assert state['file'] == None
+        assert state['code'] == 200
+        assert state['priority'] == 0
+
+    if 'slave' in config['states']:
+        state = config['states']['slave']
+        assert state['file'] == '/var/lib/plight/node_slave'
+        assert state['code'] == 200
+        assert state['priority'] == 1


### PR DESCRIPTION
In an effort to enable an official 'offline' state via the web service, I decided it would be cleaner to just support more dynamically configured states.  But because I want to avoid causing upgrade issues for our small existing user base, i geared all the changes so that upon upgrade eerything should still behave exactly the same.

In the long run we'd like to possibly change the returned HTTP response code to be a 200 for every state, thus showing that the server is working.  This decision is based upon the ugliness of trying to associate HTTP response codes to our states.  At that point we would be relying on the returned message for state checking.

In the configuration file you will see that the permanants (we named that poorly) section has been replaced with a section per state, and a new section called priorities. Under priorities you would provide a comma separated list, from lowest priority to highest.  Lowest priority should equate to your default state, typically called 'enabled'.  This list is also how the config parser looks up sections in the configuration.  If you have a section defined for a state, but it is not in the priorities.states list it will be ignored.