### PR TITLE
add exit() to end of cli_fail() function

### DIFF
--- a/plight/util.py
+++ b/plight/util.py
@@ -107,7 +107,8 @@ def stop_server():
         print "no pid file available"
 
 def cli_fail():
-    sys.stderr.write('{0} [start|enable|disable|stop]'.format(sys.argv[0]))
+    sys.stderr.write('{0} [start|enable|disable|stop]\n'.format(sys.argv[0]))
+    exit(1)
 
 def run():
     try:


### PR DESCRIPTION
If you run "plight" with no arguments, it displays the usage information through the cli_fail function.  The script never exits and continues.  The local variable "mode" is not yet defined, which throws an exception.

