### PR TITLE
/var/run as tmpfs prevents pligth from starting sometimes

### DIFF
--- a/plight/util.py
+++ b/plight/util.py
@@ -117,7 +117,7 @@ def process_states_from_config(parser, logger):
     return states
 
 
-def start_server(config, node):
+def start_server(config):
     weblogger = logging.getLogger('plight_httpd')
     weblogger.setLevel(config['web_log_level'])
     if weblogger.handlers == []:
@@ -213,7 +213,7 @@ def run():
     if mode in node._commands:
         node.set_node_state(mode)
     elif mode == 'start':
-        start_server(config, node)
+        start_server(config)
     elif mode == 'stop':
         stop_server()
     else:

--- a/scripts/plightd.init
+++ b/scripts/plightd.init
@@ -86,7 +86,12 @@ def start():
     mount filesystems, etc.
     """
     print('Starting...', end='')
-    verify_pid_dir()
+    try:
+        verify_pid_dir()
+    except:
+        echo_failure()
+        sys.stderr.write('Verify that {0} exists and is owned by plight\n'.format(
+            os.path.dirname(plight.util.PID_FILE)))
     lock()
     # success first because the daemonize stop the printing
     # TODO: fixme

--- a/scripts/plightd.init
+++ b/scripts/plightd.init
@@ -70,12 +70,23 @@ def unlock():
     if os.path.isfile(LOCK_FILE):
         os.remove(LOCK_FILE)
 
+def verify_pid_dir():
+    pid_dir = os.path.dirname(plight.util.PID_FILE)
+    if not os.path.exists(pid_dir):
+        import pwd
+        import grp
+        uid = pwd.getpwnam('plight').pw_uid
+        gid = grp.getgrnam('plight').gr_gid
+        os.mkdir(pid_dir, 0755)
+        os.chown(pid_dir, uid, gid)
+
 def start():
     """
     Do whatever needs to be done.. this is where you start any applications,
     mount filesystems, etc.
     """
     print('Starting...', end='')
+    verify_pid_dir()
     lock()
     # success first because the daemonize stop the printing
     # TODO: fixme

--- a/scripts/plightd.init
+++ b/scripts/plightd.init
@@ -28,8 +28,14 @@ import plight.util
 # service name, necessary paths
 SERVICE = 'plight'
 SERVICE_NAME = str(sys.argv[0]).strip().lower()
-LOCK_FILE = '/var/lock/subsys/' + SERVICE
 
+# Because RH and other distributions use different directories
+# for sysvinit locking states we try and decipher that here
+LOCK_DIR = '/var/lock'
+RH_LOCK_DIR = os.path.join(LOCK_DIR, 'subsys')
+if os.path.isdir(RH_LOCK_DIR):
+    LOCK_DIR = RH_LOCK_DIR
+LOCK_FILE = os.path.join(LOCK_DIR, SERVICE)
 
 # ANSI codes
 MOVE_CURSOR = '\033[60G'

--- a/scripts/plightd.service
+++ b/scripts/plightd.service
@@ -5,7 +5,10 @@ After=network.target
 [Service]
 User=plight
 Group=plight
-PIDFile=/var/run/plight.pid
+PIDFile=/var/run/plight/plight.pid
+PermissionsStartOnly=true
+ExecStartPre=-/usr/bin/mkdir /var/run/plight
+ExecStartPre=/usr/bin/chown -R plight:plight /var/run/plight
 ExecStart=/usr/bin/plight start
 ExecStop=/usr/bin/plight stop
 


### PR DESCRIPTION
When /var/run/plight is missing Plight wont start. Because /var/run is now a tmpfs that clears at each system boot this isnt covered by the RPM providing the directory.

Need to provide some better validation and create the directory ourselves as room in the startup process.