### PR TITLE
adding plight status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,12 @@ configured states.
 #### Return a node to active mode
 ```plight enable```
 
+#### List the configured states
+```plight list-states```
+
 #### Checking the current state of a node
+```plight status```  
+      or  
 ```curl http://localhost:10101 -D -```
 
 ## Licensing

--- a/plight/util.py
+++ b/plight/util.py
@@ -192,8 +192,24 @@ def stop_server():
         print('no pid file available')
 
 
+def format_get_current_state(state, details):
+    message = 'State: {0}\nCode: {1}\nMessage: {2}\n'
+    sys.stdout.write(message.format(state, details['code'], details['message']))
+
+
+def format_list_states(default, states):
+    for state, details in states.items():
+        message_modifier = ''
+        if state == default:
+            message_modifier = ' [default]'
+        message = 'State: {0}{1}\nCode: {2}\nMessage: {3}\n\n'
+        sys.stdout.write(
+            message.format(
+                state, message_modifier, details['code'], details['message']))
+
+
 def cli_fail(commands):
-    fail_msg = '{0} [start|{1}|stop]\n'
+    fail_msg = '{0} [start|{1}|list-states|status|stop]\n'
     commands = "|".join(commands)
     sys.stderr.write(fail_msg.format(sys.argv[0], commands))
     exit(1)
@@ -209,12 +225,15 @@ def run():
         cli_fail(node._commands)
     except AttributeError:
         cli_fail(node._commands)
-
     if mode in node._commands:
         log_message('Changing state to {0}'.format(mode))
         node.set_node_state(mode)
     elif mode == 'start':
         start_server(config)
+    elif mode == 'status':
+        format_get_current_state(node.state, config['states'][node.state])
+    elif mode == 'list-states':
+        format_list_states(node._default_state, config['states'])
     elif mode == 'stop':
         stop_server()
     else:

--- a/plight/util.py
+++ b/plight/util.py
@@ -69,7 +69,7 @@ def process_states_from_config(parser, logger):
         logger.warn('Permanents section is deprecated, see release notes')
         states['disabled']['file'] = state_file
         states['disabled']['old_config'] = True
-        del states['offline']
+        states.pop('offline', None)
     if 'old_config' not in states['disabled']:
         # We are on the new config.  Valid states are pulled
         # from the defined priorities.states, which should be ordered

--- a/plight/util.py
+++ b/plight/util.py
@@ -194,7 +194,8 @@ def stop_server():
 
 def format_get_current_state(state, details):
     message = 'State: {0}\nCode: {1}\nMessage: {2}\n'
-    sys.stdout.write(message.format(state, details['code'], details['message']))
+    sys.stdout.write(
+        message.format(state, details['code'], details['message']))
 
 
 def format_list_states(default, states):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -147,3 +147,30 @@ def test_get_config(config_file):
         assert state['file'] == '/var/lib/plight/node_slave'
         assert state['code'] == 200
         assert state['priority'] == 1
+
+def test_format_list_states(capsys, config_file):
+    config = util.get_config(config_file)
+    states = config['states']
+    check = ''
+    for state, details in states.items():
+        if details['file'] is None:
+            message_modifier = ' [default]'
+        else:
+            message_modifier = ''
+        check += 'State: {0}{1}\nCode: {2}\nMessage: {3}\n\n'.format(
+            state, message_modifier, details['code'], details['message'])
+
+    util.format_list_states('enabled', config['states'])
+    out, err = capsys.readouterr()
+    assert out == check
+
+def test_format_get_current_state(capsys, config_file):
+    config = util.get_config(config_file)
+    states = config['states']
+    check = ''
+    for state, details in states.items():
+        message = 'State: {0}\nCode: {1}\nMessage: {2}\n'
+        check = message.format(state, details['code'], details['message'])
+        util.format_get_current_state(state, details)
+        out, err = capsys.readouterr()
+        assert out == check


### PR DESCRIPTION
PYTHONPATH= py.test
=============================================== test session starts ===============================================
platform linux2 -- Python 2.7.5 -- py-1.4.27 -- pytest-2.7.1
rootdir: /home/tony4715/plight, inifile: 
collected 18 items 

tests/test_plight.py .........
tests/test_util.py .........

============================================ 18 passed in 0.06 seconds ============================================