### PR TITLE
Add feature to offer secure lockfile usage

### DIFF
--- a/plight.conf
+++ b/plight.conf
@@ -2,11 +2,12 @@
 port = 10101
 host = 0.0.0.0
 user = plight 
-group = plight 
+group = plight
 logfile = /var/log/plight/access.log
 loglevel = INFO
 filesize = 1024000
 rotationcount = 10
+lockfile_securemode = 0660
 
 [logging]
 logfile = /var/log/plight/plight.log

--- a/plight.spec
+++ b/plight.spec
@@ -4,7 +4,7 @@
 %{!?_unitdir: %define _unitdir /usr/lib/systemd/system}
 
 Name:           plight
-Version:        0.1.2
+Version:        0.2.0
 Release:        1%{?dist}
 Group:          Applications/Systems
 Summary:        Application agnostic tool to represent node availability.
@@ -118,6 +118,10 @@ fi
 %endif
 
 %changelog
+* Thu Apr 6 2017 Jonathan Kelley <jon.kelley@rackspace.com> - 0.2.0-1
+- Adding chown pidfile feature for securing pid files on compliance / enterprise systems.
+- Add shutil python standard module dependecy
+
 * Fri Jun 19 2015 Greg Swift <greg.swift@rackspace.com> - 0.1.2-1
 - Fixes to work better when singleton doesnt take, like on py2.6
 

--- a/plight/__init__.py
+++ b/plight/__init__.py
@@ -3,7 +3,7 @@
 
 """
 
-__version__ = '0.1.2'
+__version__ = '0.2.0'
 __license__ = 'ASLv2'
 __all__ = ['StatusHTTPRequestHandler', 'NodeStatus']
 __author__ = 'Alex Schultz'

--- a/plight/config.py
+++ b/plight/config.py
@@ -35,6 +35,15 @@ PID_FILE = '/var/run/plight/plight.pid'
 def get_config(config_file=CONFIG_FILE):
     parser = ConfigParser.ConfigParser()
     parser.read(config_file)
+    try:
+        # python 2.x uses isinstance(s, basestring) and
+        # python 3.x uses isinstance(s, str) ((basestring is undefined))
+        # and ConfigParser.ConfigParser() doesn't have a default key option
+        pid_file_mode = parser.getint('webserver', 'pid_file_mode')
+    except:
+        # This is version agnostic.
+        pid_file_mode = False
+
     config = {
         'host': parser.get('webserver', 'host'),
         'port': parser.getint('webserver', 'port'),
@@ -45,6 +54,7 @@ def get_config(config_file=CONFIG_FILE):
                                  parser.get('webserver', 'loglevel')),
         'web_log_filesize': parser.getint('webserver', 'filesize'),
         'web_log_rotation_count': parser.getint('webserver', 'rotationcount'),
+        'pid_file_mode': pid_file_mode,
         'log_file': parser.get('logging', 'logfile'),
         'log_level': getattr(logging,
                              parser.get('logging', 'loglevel')),

--- a/plight/util.py
+++ b/plight/util.py
@@ -3,7 +3,6 @@
 from __future__ import print_function
 
 import os
-from shutil import chown
 import pwd
 import grp
 import sys
@@ -47,7 +46,9 @@ def secure_pid_permissions(user, group, securemode=None):
 
     try:
         if securemode:
-            chown(PID.path, user=user, group=group)
+            uid = pwd.getpwnam(user).pw_uid
+            gid = grp.getgrnam(group).gr_gid
+            os.chown(PID.path, uid, gid)
     except Exception as e:
         log_message("Exeption while setting file ownership on ``{0}``: {1}".format(PID.path, e))
         secure=False
@@ -96,7 +97,8 @@ def start_server(config):
     # Secures the lockfile/pid to the user/group and preferred mode
     secure_pid_permissions(user=config['user'],
         group=config['group'],
-        mode=config['pid_file_mode']
+        mode=config['pid_file_mode'],
+        securemode=config.get('pid_file_mode', None)
         )
     os.umask(0o022)
 
@@ -182,3 +184,4 @@ def run():
         stop_server()
     else:
         cli_fail(node._commands)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ logfile = /var/log/plight/access.log
 loglevel = INFO
 filesize = 1024000
 rotationcount = 10
+lockfile_securemode = 0660
 
 [logging]
 logfile = /var/log/plight/plight.log
@@ -73,6 +74,7 @@ logfile = /var/log/plight/access.log
 loglevel = INFO
 filesize = 1024000
 rotationcount = 10
+lockfile_securemode = 0660
 
 [logging]
 logfile = /var/log/plight/plight.log

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,8 @@ def test_get_config(config):
     assert config['port'] == 10101
     assert config['web_log_file'] == '/var/log/plight/access.log'
     assert config['log_file'] == '/var/log/plight/plight.log'
+    assert config['lockfile_securemode'] == 0660
+
     if 'enabled' in config['states']:
         state = config['states']['enabled']
         assert state['file'] == None


### PR DESCRIPTION
Certain environments may require lockfiles (pid files) that aren't world readable for extra security

Inside ```plight.conf``` set lockfile_securemode to an octal integer (```0600``` etc) or set it to a ```str``` or ```False``` to disable secure lockfile behavior altogether.